### PR TITLE
tpm_command_handler: fix switch fallthrough

### DIFF
--- a/tpm/tpm_cmd_handler.c
+++ b/tpm/tpm_cmd_handler.c
@@ -3330,6 +3330,7 @@ static void tpm_setup_rsp_auth(TPM_COMMAND_CODE ordinal, TPM_RESPONSE *rsp)
                   sizeof(rsp->auth2->nonceOdd.nonce));
       tpm_hmac_update(&hmac, (BYTE*)&rsp->auth2->continueAuthSession, 1);
       tpm_hmac_final(&hmac, rsp->auth2->auth);
+      break;
     case TPM_TAG_RSP_AUTH1_COMMAND:
       tpm_hmac_init(&hmac, rsp->auth1->secret, sizeof(rsp->auth1->secret));
       tpm_hmac_update(&hmac, rsp->auth1->digest, sizeof(rsp->auth1->digest));


### PR DESCRIPTION
Compiling with a recent GCC fails as follows:

  tpm-emulator/tpm/tpm_cmd_handler.c: In function ‘tpm_setup_rsp_auth’:
  tpm-emulator/tpm/tpm_cmd_handler.c:3332:7: error: this statement may fall through [-Werror=implicit-fallthrough=]
         tpm_hmac_final(&hmac, rsp->auth2->auth);
         ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
  tpm-emulator/tpm/tpm_cmd_handler.c:3333:5: note: here
       case TPM_TAG_RSP_AUTH1_COMMAND:

Looking at the code, this does indeed seem unintentional. Add a break
state in the appropriate place.