### PR TITLE
fix the problem of memory leak when invoking "tpmd_disconnect"

### DIFF
--- a/tpmd_dev/linux/tpmd_dev.c
+++ b/tpmd_dev/linux/tpmd_dev.c
@@ -87,7 +87,7 @@ static int tpmd_connect(char *socket_name)
     (struct sockaddr*)&addr, sizeof(struct sockaddr_un), 0);
   if (res != 0) {
     error("sock_connect() failed: %d\n", res);
-    tpmd_sock->ops->release(tpmd_sock);
+    sock_release(tpmd_sock);
     tpmd_sock = NULL;
     return res;
   }
@@ -96,7 +96,7 @@ static int tpmd_connect(char *socket_name)
 
 static void tpmd_disconnect(void)
 {
-  if (tpmd_sock != NULL) tpmd_sock->ops->release(tpmd_sock);
+  if (tpmd_sock != NULL) sock_release(tpmd_sock);
   tpmd_sock = NULL;
 }
 


### PR DESCRIPTION
I maked a experiment by invoking tpmd_connect and tpmd_disconnect many times. Then, i found memory leak by entering command "cat /proc/slabinfo | grep sock_inode_cache".
After studing the the code of  function sock_release, i realized  tpmd_sock->ops->release not free memory. Free memory is realized by iput(SOCK_INODE(sock)).
So, i think we should use sock_release instand of tpmd_sock->ops->release.