### PR TITLE
tpm: tpm_deprecated.c fix compare

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -67,7 +67,9 @@ include_directories(${CMAKE_BINARY_DIR})
 
 # add internal libraries
 add_subdirectory(tpm)
-add_subdirectory(mtm)
+if(MTM_EMULATOR)
+    add_subdirectory(mtm)
+endif()
 add_subdirectory(crypto)
 
 # add TDDL

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,6 +6,7 @@
 project(TPM_Emulator C)
 
 cmake_minimum_required(VERSION 2.4)
+include(GNUInstallDirs)
 set(CMAKE_ALLOW_LOOSE_LOOP_CONSTRUCTS true)
 if(COMMAND cmake_policy)
 cmake_policy(SET CMP0003 NEW)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -76,7 +76,12 @@ add_subdirectory(crypto)
 add_subdirectory(tddl)
 
 # add kernel modules
-add_subdirectory(tpmd_dev)
+if(NOT DEFINED BUILD_DEV)
+    set(BUILD_DEV ON)
+endif()
+if(BUILD_DEV)
+    add_subdirectory(tpmd_dev)
+endif()
 
 # add executables
 add_subdirectory(tpmd)

--- a/tddl/CMakeLists.txt
+++ b/tddl/CMakeLists.txt
@@ -15,9 +15,9 @@ elseif(WIN32)
   set_target_properties(tddl PROPERTIES PREFIX "")
 endif()
 
-install(TARGETS tddl DESTINATION lib)
-install(TARGETS tddl_static DESTINATION lib)
-install(FILES "tddl.h" DESTINATION include)
+install(TARGETS tddl DESTINATION ${CMAKE_INSTALL_LIBDIR})
+install(TARGETS tddl_static DESTINATION ${CMAKE_INSTALL_LIBDIR})
+install(FILES "tddl.h" DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})
 
 include_directories(${CMAKE_CURRENT_SOURCE_DIR})
 add_executable(test_tddl test_tddl.c)

--- a/tpm/tpm_cmd_handler.c
+++ b/tpm/tpm_cmd_handler.c
@@ -3330,6 +3330,7 @@ static void tpm_setup_rsp_auth(TPM_COMMAND_CODE ordinal, TPM_RESPONSE *rsp)
                   sizeof(rsp->auth2->nonceOdd.nonce));
       tpm_hmac_update(&hmac, (BYTE*)&rsp->auth2->continueAuthSession, 1);
       tpm_hmac_final(&hmac, rsp->auth2->auth);
+      break;
     case TPM_TAG_RSP_AUTH1_COMMAND:
       tpm_hmac_init(&hmac, rsp->auth1->secret, sizeof(rsp->auth1->secret));
       tpm_hmac_update(&hmac, rsp->auth1->digest, sizeof(rsp->auth1->digest));

--- a/tpm/tpm_deprecated.c
+++ b/tpm/tpm_deprecated.c
@@ -434,7 +434,7 @@ TPM_RESULT TPM_ChangeAuthAsymFinish(TPM_KEY_HANDLE parentHandle,
   tpm_hmac_final(&hmac_ctx, b1.digest);
   /* 6. The TPM SHALL compare b1 with newAuthLink. The TPM SHALL
         indicate a failure if the values do not match. */
-  if (memcmp(&b1, &newAuthLink, sizeof(TPM_HMAC))) {
+  if (memcmp(&b1, newAuthLink, sizeof(TPM_HMAC))) {
     debug("TPM_ChangeAuthAsymFinish(): newAuthLink value does not match.");
     return TPM_FAIL;
   }

--- a/tpmd/unix/CMakeLists.txt
+++ b/tpmd/unix/CMakeLists.txt
@@ -13,5 +13,5 @@ target_link_libraries(tpmd mtm tpm tpm_crypto)
 else()
 target_link_libraries(tpmd tpm tpm_crypto)
 endif()
-install(TARGETS tpmd RUNTIME DESTINATION bin)
+install(TARGETS tpmd RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR})
 


### PR DESCRIPTION
tpm/tpm_deprecated.c:437:7: error: ‘__builtin_memcmp_eq’ reading 20 bytes from a region of size 8 [-Werror=stringop-overflow=]
   if (memcmp(&b1, &newAuthLink, sizeof(TPM_HMAC))) {
       ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
cc1: all warnings being treated as errors

Bug: https://bugs.gentoo.org/show_bug.cgi?id=664198