### PR TITLE
tpmd_dev: fix strncpy bound

### DIFF
--- a/tpmd_dev/linux/tpmd_dev.c
+++ b/tpmd_dev/linux/tpmd_dev.c
@@ -85,7 +85,7 @@ static int tpmd_connect(char *socket_name)
     return res;
   }
   addr.sun_family = AF_UNIX;
-  strncpy(addr.sun_path, socket_name, sizeof(addr.sun_path));
+  strncpy(addr.sun_path, socket_name, sizeof(addr.sun_path)-1);
   res = tpmd_sock->ops->connect(tpmd_sock,
     (struct sockaddr*)&addr, sizeof(struct sockaddr_un), 0);
   if (res != 0) {


### PR DESCRIPTION
tpmd_dev/linux/tpmd_dev.c:88:3: error: ‘strncpy’ specified bound 108 equals destination size [-Werror=stringop-truncation]

Signed-off-by: Alon Bar-Lev <alon.barlev@gmail.com>