### PR TITLE
add extern to function declarations

### DIFF
--- a/tpm/tpm_emulator_extern.h
+++ b/tpm/tpm_emulator_extern.h
@@ -29,7 +29,7 @@ enum {
   TPM_LOG_ERROR
 };
 
-void (*tpm_log)(int priority, const char *fmt, ...);
+extern void (*tpm_log)(int priority, const char *fmt, ...);
 
 #if defined(_WIN32) || defined(_WIN64)
 #define __BFILE__ ((strrchr(__FILE__, '\\') ? : __FILE__ - 1) + 1)
@@ -44,27 +44,27 @@ void (*tpm_log)(int priority, const char *fmt, ...);
 #define error(fmt, ...) tpm_log(TPM_LOG_ERROR, "%s:%d: Error: " fmt "\n", \
                                 __BFILE__, __LINE__, ## __VA_ARGS__)
 /* initialization */
-int (*tpm_extern_init)(void);
-void (*tpm_extern_release)(void);
+extern int (*tpm_extern_init)(void);
+extern void (*tpm_extern_release)(void);
 
 /* memory allocation */
 
-void* (*tpm_malloc)(size_t size);
+extern void* (*tpm_malloc)(size_t size);
 
-void (*tpm_free)(/*const*/ void *ptr);
+extern void (*tpm_free)(/*const*/ void *ptr);
 
 /* random numbers */
 
-void (*tpm_get_extern_random_bytes)(void *buf, size_t nbytes);
+extern void (*tpm_get_extern_random_bytes)(void *buf, size_t nbytes);
 
 /* usec since last call */
 
-uint64_t (*tpm_get_ticks)(void);
+extern uint64_t (*tpm_get_ticks)(void);
 
 /* file handling */
 
-int (*tpm_write_to_storage)(uint8_t *data, size_t data_length);
-int (*tpm_read_from_storage)(uint8_t **data, size_t *data_length);
+extern int (*tpm_write_to_storage)(uint8_t *data, size_t data_length);
+extern int (*tpm_read_from_storage)(uint8_t **data, size_t *data_length);
 
 #endif /* _TPM_EMULATOR_EXTERN_H_ */
 


### PR DESCRIPTION
Code compiled with gcc10 will not link properly due to multiple
definition of the same function.

ld: /home/abuild/rpmbuild/BUILD/xen-4.8.20191211T160002.8db85532cb/non-dbg/stubdom/vtpm/vtpm.a(vtpm_cmd.o):(.bss+0x28): multiple definition of `tpm_malloc'; /home/abuild/rpmbuild/BUILD/xen-4.8.20191211T160002.8db85532cb/non-dbg/stubdom/vtpm/vtpm.a(vtpm.o):(.bss+0x728): first defined here

Signed-off-by: Olaf Hering <olaf@aepfle.de>
Reviewed-by: Jason Andryuk <jandryuk@gmail.com>
Acked-by: Samuel Thibault <samuel.thibaut@ens-lyon.org>
Reviewed-by: Ian Jackson <ian.jackson@eu.citrix.com>
Release-acked-by: Paul Durrant <paul@xen.org>

Move over from xen repo.

Signed-off-by: Jason Andryuk <jandryuk@gmail.com>