### PR TITLE
Fix xen-tpmfront timeouts

### DIFF
--- a/tpm/tpm_data.c
+++ b/tpm/tpm_data.c
@@ -71,9 +71,9 @@ static void init_timeouts(void)
   tpmData.permanent.data.tis_timeouts[1] = 2000000;
   tpmData.permanent.data.tis_timeouts[2] = 750000;
   tpmData.permanent.data.tis_timeouts[3] = 750000;
-  tpmData.permanent.data.cmd_durations[0] = 1000;
-  tpmData.permanent.data.cmd_durations[1] = 10000;
-  tpmData.permanent.data.cmd_durations[2] = 1000000;
+  tpmData.permanent.data.cmd_durations[0] = 3000000;
+  tpmData.permanent.data.cmd_durations[1] = 3000000;
+  tpmData.permanent.data.cmd_durations[2] = 600000000;
 }
 
 void tpm_init_data(void)

--- a/tpm/tpm_data.c
+++ b/tpm/tpm_data.c
@@ -67,13 +67,13 @@ static void init_nv_storage(void)
 static void init_timeouts(void)
 {
   /* for the timeouts we use the PC platform defaults */
-  tpmData.permanent.data.tis_timeouts[0] = 750;
-  tpmData.permanent.data.tis_timeouts[1] = 2000;
-  tpmData.permanent.data.tis_timeouts[2] = 750;
-  tpmData.permanent.data.tis_timeouts[3] = 750;
-  tpmData.permanent.data.cmd_durations[0] = 1;
-  tpmData.permanent.data.cmd_durations[1] = 10;
-  tpmData.permanent.data.cmd_durations[2] = 1000;
+  tpmData.permanent.data.tis_timeouts[0] = 750000;
+  tpmData.permanent.data.tis_timeouts[1] = 2000000;
+  tpmData.permanent.data.tis_timeouts[2] = 750000;
+  tpmData.permanent.data.tis_timeouts[3] = 750000;
+  tpmData.permanent.data.cmd_durations[0] = 1000;
+  tpmData.permanent.data.cmd_durations[1] = 10000;
+  tpmData.permanent.data.cmd_durations[2] = 1000000;
 }
 
 void tpm_init_data(void)


### PR DESCRIPTION
Linux adjusts the timeouts since they should be in microseconds, but seem to be in milliseconds.  Correct that for timeouts and duration since they should both be in microseconds.

Testing with Xen vtpm stubdoms and Linux 5.4, I was seeing commands fail with -ETIME.  Increasing the command duration fixes that.  I took them from a real TPM1.2.  The tpm_emulator should beat that, but I'd rather give it more time than have commands time out.
