### PR TITLE
Update stale/broken MinGW URL for Windows-based development

### DIFF
--- a/README
+++ b/README
@@ -46,7 +46,7 @@ The compilation and installation of the TPM emulator package is based on
 the CMake build environment (version 2.6 or better) and requires that the 
 GNU MP library (version 4.0 or better) is properly installed on your
 system. A working MinGW compiler suite is further required on Windows
-(see http://www.mingw.org/). To compile and install the package execute:
+(see https://www.mingw-w64.org/). To compile and install the package execute:
 
 # tar -xvzf tpm_emulator-X.Y.tar.gz
 # cd tpm_emulator-X.Y


### PR DESCRIPTION
The URL http://mingw.org/ that was previously provided for Windows-based development has fallen out of use and now redirects to nowhere useful. I have updated the README to point to a more useful alternative being the MinGW-w64.org site, which began as a 64-bit fork of the original, but now represents a more viable alternative to the broken link. Some anecdotal evidence around Reddit suggests that https://gcc.gnu.org/ should be the replacement, but this isn't as immediately obvious or helpful as the URL I have offered as a replacement.