### PR TITLE
Fix header file name missed in https://github.com/PeterHuewe/tpm-emul…

### DIFF
--- a/tddl/tddl_windows.h
+++ b/tddl/tddl_windows.h
@@ -19,7 +19,7 @@
 #include <errno.h>
 #include <windows.h>
 #include <config.h>
-#include "tddl.h"
+#include "tddl-tpm-emulator.h"
 
 /* library lock */
 static CRITICAL_SECTION tddli_lock;


### PR DESCRIPTION
Fix a problem with header file renamig that only affects the Windows build following the renaming of tddl.h as part of: 
https://github.com/PeterHuewe/tpm-emulator/pull/49/commits/fd3cfe8615507a95a6be55bcc13a64a21035fe23#